### PR TITLE
Seperate Repo and Terms indexer and schedule at 5p and 6p respectively

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -141,6 +141,7 @@ function getConfig(env='development') {
   // Repos are set to a default of once a day at 5pm
   // Issues are set to run every 3 hours
   config.REPOS_INDEX_CRON_CONFIG = process.env.REPOS_INDEX_CRON_CONFIG || '0 17 * * *';
+  config.REPOS_INDEX_CRON_CONFIG = process.env.TERMS_INDEX_CRON_CONFIG || '0 18 * * *';
   config.ISSUE_INDEX_CRON_CONFIG = process.env.ISSUE_INDEX_CRON_CONFIG || '0 */3 * * *';
 
   Object.assign(config, getAppFilesDirectories(config.GET_REMOTE_METADATA));

--- a/scripts/index/index.js
+++ b/scripts/index/index.js
@@ -23,10 +23,18 @@ class Indexer {
 
   async indexRepos() {
     let repoIndexer = new RepoIndexer(this.config);
-    let termIndexer = new TermIndexer(this.config);
 
     try {
       await repoIndexer.index();
+    } catch(error) {
+      this.logger.error(error);
+      throw error;
+    }
+  }
+  async indexTerms() {
+    let termIndexer = new TermIndexer(this.config);
+
+    try {
       await termIndexer.index();
     } catch(error) {
       this.logger.error(error);
@@ -68,6 +76,12 @@ if (require.main === module) {
     cronConfig: config.REPOS_INDEX_CRON_CONFIG,
     scheduleParameters,
     targetFunction: indexer.indexRepos.bind(indexer)
+  });
+  indexer.schedule({
+    jobName: `index-terms`,
+    cronConfig: config.TERMS_INDEX_CRON_CONFIG,
+    scheduleParameters,
+    targetFunction: indexer.indexTerms.bind(indexer)
   });
   indexer.schedule({
     jobName: `index-issues`,


### PR DESCRIPTION
This PR changes separates Repos and Terms Index creation and schedule them at 5p and 6p respectively.  Address functionality on trello card https://trello.com/c/i2b93jLX